### PR TITLE
Fix test failure on --libs-only-l with libz

### DIFF
--- a/test/test_pkg_config.rb
+++ b/test/test_pkg_config.rb
@@ -54,7 +54,7 @@ class PkgConfigTest < Test::Unit::TestCase
 
     @cairo_png.msvc_syntax = true
     result = pkg_config("cairo-png", "--libs-only-l")
-    msvc_result = result.gsub(/-l(cairo|png[0-9]+)\b/, '\1.lib')
+    msvc_result = result.gsub(/-l(cairo|png[0-9]+|z)\b/, '\1.lib')
     assert_not_equal(msvc_result, result)
     assert_equal(msvc_result, @cairo_png.libs_only_l)
   end


### PR DESCRIPTION
Forwarded from https://bugs.debian.org/870850

```
===============================================================================
Failure: test_libs_only_l(PkgConfigTest)
/build/1st/ruby-pkg-config-1.2.3/test/test_pkg_config.rb:50:in `test_libs_only_l'
     47:     result = pkg_config("cairo-png", "--libs-only-l")
     48:     msvc_result = result.gsub(/-l(cairo|png[0-9]+)\b/, '\1.lib')
     49:     assert_not_equal(msvc_result, result)
  => 50:     assert_equal(msvc_result, @cairo_png.libs_only_l)
     51:   end
     52: 
     53:   def test_libs_only_L
<"cairo.lib png16.lib -lz">(US-ASCII) expected but was
<"cairo.lib png16.lib z.lib">(UTF-8)

diff:
? cairo.lib png16.lib - lz 
?                     z. ib
  
? Encoding: US -ASCII
?            TF 8    
===============================================================================
```